### PR TITLE
DCM tagFormats default update

### DIFF
--- a/upload/dcapi.py
+++ b/upload/dcapi.py
@@ -514,7 +514,7 @@ class Placement(object):
 
     def create_p_dict(self):
         if not self.tagFormats:
-            self.tagFormats = 'PLACEMENT_TAG_STANDARD'
+            self.tagFormats = 'PLACEMENT_TAG_TRACKING'
         if not self.compatibility:
             self.compatibility = 'DISPLAY'
         p_dict = {


### PR DESCRIPTION
- Change tagFormats default value from 'PLACEMENT_TAG_STANDARD' to 'PLACEMENT_TAG_TRACKING' in DCM uploader ad set level in creation

In tandem with https://github.com/Jamezzz5/lqapp/pull/297